### PR TITLE
🚀 2단계 - 중복 제거와 구조화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     // Cucumber
     testImplementation "io.cucumber:cucumber-java:${cucumberVersion}"
     testImplementation "io.cucumber:cucumber-junit-platform-engine:${cucumberVersion}"
+    testImplementation "io.cucumber:cucumber-picocontainer:${cucumberVersion}"
     
     // RestAssured
     testImplementation "io.rest-assured:rest-assured:${restAssuredVersion}"

--- a/src/test/java/com/camping/admin/runner/CucumberTestRunner.java
+++ b/src/test/java/com/camping/admin/runner/CucumberTestRunner.java
@@ -1,8 +1,12 @@
+package com.camping.admin.runner;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
 import org.junit.platform.suite.api.SelectClasspathResource;
 import org.junit.platform.suite.api.Suite;
 
 @Suite
 @SelectClasspathResource("features")
+@ConfigurationParameter(key = "cucumber.glue", value = "com.camping.admin")
 public class CucumberTestRunner {
 
 }

--- a/src/test/java/com/camping/admin/steps/ReservationStepDefs.java
+++ b/src/test/java/com/camping/admin/steps/ReservationStepDefs.java
@@ -7,6 +7,7 @@ import com.camping.admin.dto.ReservationResponse;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import io.restassured.response.ExtractableResponse;
 import java.util.Map;
 import org.springframework.http.HttpStatus;
 
@@ -15,6 +16,7 @@ public class ReservationStepDefs {
     private Long reservationId;
     private String adminToken;
     private String status;
+    private ExtractableResponse response;
 
     @Given("WATING 상태인 예약이 존재한다.")
     public void wating상태인예약이존재한다() {
@@ -49,5 +51,37 @@ public class ReservationStepDefs {
     @Then("예약 상태가 PENDING 으로 변경된다.")
     public void 예약상태가PENDING으로변경된다() {
         assertThat(status).isEqualTo("PENDING");
+    }
+
+    @Given("존재하지 않는 예약 ID 9999 가 있다.")
+    public void 존재하지않는예약ID가있다() {
+        reservationId = 9999L;
+    }
+
+    @When("관리자가 예약 ID 9999 의 상태를 PENDING 상태로 변경한다.")
+    public void 관리자가예약ID의상태를PENDING상태로변경한다() {
+        adminToken = given()
+                .contentType("application/json")
+                .body(Map.of("username", "admin", "password", "admin123"))
+                .when().post("/auth/login")
+                .then().log().all()
+                .extract()
+                .cookie("AUTH_TOKEN");
+
+        var body = Map.of("status", "PENDING");
+
+        response = given()
+                .contentType("application/json")
+                .header("Authorization", "Bearer " + adminToken)
+                .body(body)
+                .when()
+                .patch("/admin/reservations/{id}/status", reservationId)
+                .then().log().all()
+                .extract();
+    }
+
+    @Then("에러 응답이 발생한다.")
+    public void 에러응답이발생한다() {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
     }
 }

--- a/src/test/java/com/camping/admin/steps/ReservationStepDefs.java
+++ b/src/test/java/com/camping/admin/steps/ReservationStepDefs.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.camping.admin.dto.ReservationResponse;
 import com.camping.admin.support.api.AuthApi;
+import com.camping.admin.support.api.ReservationApi;
 import com.camping.admin.support.context.ReservationWorld;
 import io.cucumber.java.PendingException;
 import io.cucumber.java.en.Given;
@@ -18,6 +19,7 @@ public class ReservationStepDefs {
 
     private final ReservationWorld world;
     private final AuthApi authApi = new AuthApi();
+    private final ReservationApi reservationApi = new ReservationApi();
 
     public ReservationStepDefs(ReservationWorld world) {
         this.world = world;
@@ -35,17 +37,7 @@ public class ReservationStepDefs {
 
     @When("관리자가 WATING 상태인 예약 상태를 PENDING 상태로 변경한다.")
     public void 관리자가WATING상태인예약상태를PENDING상태로변경한다() {
-        var body = Map.of("status", "PENDING");
-        var response = given()
-                .contentType("application/json")
-                .header("Authorization", "Bearer " + world.authToken)
-                .body(body)
-                .when()
-                .patch("/admin/reservations/{id}/status", world.reservationId)
-                .then().log().all()
-                .statusCode(HttpStatus.OK.value())
-                .extract();
-
+        var response = reservationApi.patchStatus(world.authToken, world.reservationId, "PENDING");
         ReservationResponse reservationResponse = response.as(ReservationResponse.class);
         world.status = reservationResponse.getStatus();
     }
@@ -62,15 +54,7 @@ public class ReservationStepDefs {
 
     @When("관리자가 예약 ID 9999 의 상태를 PENDING 상태로 변경한다.")
     public void 관리자가예약ID의상태를PENDING상태로변경한다() {
-        var body = Map.of("status", "PENDING");
-        world.response = given()
-                .contentType("application/json")
-                .header("Authorization", "Bearer " + world.authToken)
-                .body(body)
-                .when()
-                .patch("/admin/reservations/{id}/status", world.reservationId)
-                .then().log().all()
-                .extract();
+        world.response = reservationApi.patchStatus(world.authToken, world.reservationId, "PENDING");
     }
 
     @Then("에러 응답이 발생한다.")

--- a/src/test/java/com/camping/admin/steps/ReservationStepDefs.java
+++ b/src/test/java/com/camping/admin/steps/ReservationStepDefs.java
@@ -23,6 +23,11 @@ public class ReservationStepDefs {
         this.world = world;
     }
 
+    @Given("관리자가 로그인을 하였다.")
+    public void 관리자가로그인을하였다() {
+        world.authToken = authApi.loginAndGetCookieToken("admin", "admin123");
+    }
+
     @Given("WATING 상태인 예약이 존재한다.")
     public void wating상태인예약이존재한다() {
         world.reservationId = 13L;
@@ -30,7 +35,6 @@ public class ReservationStepDefs {
 
     @When("관리자가 WATING 상태인 예약 상태를 PENDING 상태로 변경한다.")
     public void 관리자가WATING상태인예약상태를PENDING상태로변경한다() {
-        world.authToken = authApi.loginAndGetCookieToken("admin", "admin123");
         var body = Map.of("status", "PENDING");
         var response = given()
                 .contentType("application/json")
@@ -58,7 +62,6 @@ public class ReservationStepDefs {
 
     @When("관리자가 예약 ID 9999 의 상태를 PENDING 상태로 변경한다.")
     public void 관리자가예약ID의상태를PENDING상태로변경한다() {
-        world.authToken = authApi.loginAndGetCookieToken("admin", "admin123");
         var body = Map.of("status", "PENDING");
         world.response = given()
                 .contentType("application/json")
@@ -74,4 +77,6 @@ public class ReservationStepDefs {
     public void 에러응답이발생한다() {
         assertThat(world.response.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
     }
+
+
 }

--- a/src/test/java/com/camping/admin/steps/ReservationStepDefs.java
+++ b/src/test/java/com/camping/admin/steps/ReservationStepDefs.java
@@ -4,6 +4,9 @@ import static io.restassured.RestAssured.given;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.camping.admin.dto.ReservationResponse;
+import com.camping.admin.support.api.AuthApi;
+import com.camping.admin.support.context.ReservationWorld;
+import io.cucumber.java.PendingException;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
@@ -13,75 +16,62 @@ import org.springframework.http.HttpStatus;
 
 public class ReservationStepDefs {
 
-    private Long reservationId;
-    private String adminToken;
-    private String status;
-    private ExtractableResponse response;
+    private final ReservationWorld world;
+    private final AuthApi authApi = new AuthApi();
+
+    public ReservationStepDefs(ReservationWorld world) {
+        this.world = world;
+    }
 
     @Given("WATING 상태인 예약이 존재한다.")
     public void wating상태인예약이존재한다() {
-        reservationId = 13L;
+        world.reservationId = 13L;
     }
 
     @When("관리자가 WATING 상태인 예약 상태를 PENDING 상태로 변경한다.")
     public void 관리자가WATING상태인예약상태를PENDING상태로변경한다() {
-        adminToken = given()
-                .contentType("application/json")
-                .body(Map.of("username", "admin", "password", "admin123"))
-                .when().post("/auth/login")
-                .then().log().all()
-                .extract()
-                .cookie("AUTH_TOKEN");
-
+        world.authToken = authApi.loginAndGetCookieToken("admin", "admin123");
         var body = Map.of("status", "PENDING");
         var response = given()
                 .contentType("application/json")
-                .header("Authorization", "Bearer " + adminToken)
+                .header("Authorization", "Bearer " + world.authToken)
                 .body(body)
                 .when()
-                .patch("/admin/reservations/{id}/status", reservationId)
+                .patch("/admin/reservations/{id}/status", world.reservationId)
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .extract();
 
         ReservationResponse reservationResponse = response.as(ReservationResponse.class);
-        status = reservationResponse.getStatus();
+        world.status = reservationResponse.getStatus();
     }
 
     @Then("예약 상태가 PENDING 으로 변경된다.")
     public void 예약상태가PENDING으로변경된다() {
-        assertThat(status).isEqualTo("PENDING");
+        assertThat(world.status).isEqualTo("PENDING");
     }
 
     @Given("존재하지 않는 예약 ID 9999 가 있다.")
     public void 존재하지않는예약ID가있다() {
-        reservationId = 9999L;
+        world.reservationId = 9999L;
     }
 
     @When("관리자가 예약 ID 9999 의 상태를 PENDING 상태로 변경한다.")
     public void 관리자가예약ID의상태를PENDING상태로변경한다() {
-        adminToken = given()
-                .contentType("application/json")
-                .body(Map.of("username", "admin", "password", "admin123"))
-                .when().post("/auth/login")
-                .then().log().all()
-                .extract()
-                .cookie("AUTH_TOKEN");
-
+        world.authToken = authApi.loginAndGetCookieToken("admin", "admin123");
         var body = Map.of("status", "PENDING");
-
-        response = given()
+        world.response = given()
                 .contentType("application/json")
-                .header("Authorization", "Bearer " + adminToken)
+                .header("Authorization", "Bearer " + world.authToken)
                 .body(body)
                 .when()
-                .patch("/admin/reservations/{id}/status", reservationId)
+                .patch("/admin/reservations/{id}/status", world.reservationId)
                 .then().log().all()
                 .extract();
     }
 
     @Then("에러 응답이 발생한다.")
     public void 에러응답이발생한다() {
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+        assertThat(world.response.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
     }
 }

--- a/src/test/java/com/camping/admin/steps/ReservationStepDefs.java
+++ b/src/test/java/com/camping/admin/steps/ReservationStepDefs.java
@@ -38,8 +38,7 @@ public class ReservationStepDefs {
     @When("관리자가 WAITING 상태인 예약 상태를 PENDING 상태로 변경한다.")
     public void 관리자가WAITING상태인예약상태를PENDING상태로변경한다() {
         var response = reservationApi.patchStatus(world.authToken, world.reservationId, "PENDING");
-        ReservationResponse reservationResponse = response.as(ReservationResponse.class);
-        world.status = reservationResponse.getStatus();
+        world.status = response.jsonPath().get("status");
     }
 
     @Then("예약 상태가 PENDING 으로 변경된다.")
@@ -63,4 +62,15 @@ public class ReservationStepDefs {
     }
 
 
+    @When("특정 예약에 대해 공백 상태로 예약 상태를 변경한다.")
+    public void 특정예약에대해공백상태로예약상태를변경한다() {
+        var response = reservationApi.patchStatus(world.authToken, 1, "");
+        world.status = response.jsonPath().get("status");
+    }
+
+
+    @Then("예약 상태가 기존 상태로 유지된다.")
+    public void 예약상태가기존상태로유지된다() {
+        assertThat(world.status).isNotBlank();
+    }
 }

--- a/src/test/java/com/camping/admin/steps/ReservationStepDefs.java
+++ b/src/test/java/com/camping/admin/steps/ReservationStepDefs.java
@@ -30,13 +30,13 @@ public class ReservationStepDefs {
         world.authToken = authApi.loginAndGetCookieToken("admin", "admin123");
     }
 
-    @Given("WATING 상태인 예약이 존재한다.")
+    @Given("WAITING 상태인 예약이 존재한다.")
     public void wating상태인예약이존재한다() {
         world.reservationId = 13L;
     }
 
-    @When("관리자가 WATING 상태인 예약 상태를 PENDING 상태로 변경한다.")
-    public void 관리자가WATING상태인예약상태를PENDING상태로변경한다() {
+    @When("관리자가 WAITING 상태인 예약 상태를 PENDING 상태로 변경한다.")
+    public void 관리자가WAITING상태인예약상태를PENDING상태로변경한다() {
         var response = reservationApi.patchStatus(world.authToken, world.reservationId, "PENDING");
         ReservationResponse reservationResponse = response.as(ReservationResponse.class);
         world.status = reservationResponse.getStatus();

--- a/src/test/java/com/camping/admin/support/api/AuthApi.java
+++ b/src/test/java/com/camping/admin/support/api/AuthApi.java
@@ -1,0 +1,19 @@
+package com.camping.admin.support.api;
+
+import static io.restassured.RestAssured.given;
+
+import io.restassured.response.ExtractableResponse;
+import java.util.Map;
+
+public class AuthApi {
+
+    public String loginAndGetCookieToken(String username, String password) {
+        ExtractableResponse<?> res = given()
+                .contentType("application/json")
+                .body(Map.of("username", username, "password", password))
+                .when().post("/auth/login")
+                .then().extract();
+        return res.cookie("AUTH_TOKEN");
+    }
+
+}

--- a/src/test/java/com/camping/admin/support/api/ReservationApi.java
+++ b/src/test/java/com/camping/admin/support/api/ReservationApi.java
@@ -1,0 +1,18 @@
+package com.camping.admin.support.api;
+
+import static io.restassured.RestAssured.given;
+
+import io.restassured.response.ExtractableResponse;
+import java.util.Map;
+
+public class ReservationApi {
+
+    public ExtractableResponse<?> patchStatus(String authToken, long id, String to) {
+        return given()
+                .contentType("application/json")
+                .header("Authorization", "Bearer " + authToken)
+                .body(Map.of("status", to))
+                .when().patch("/admin/reservations/{id}/status", id)
+                .then().extract();
+    }
+}

--- a/src/test/java/com/camping/admin/support/context/ReservationWorld.java
+++ b/src/test/java/com/camping/admin/support/context/ReservationWorld.java
@@ -1,0 +1,5 @@
+package com.camping.admin.support.context;
+
+public class ReservationWorld extends World {
+    public Long reservationId;
+}

--- a/src/test/java/com/camping/admin/support/context/ReservationWorld.java
+++ b/src/test/java/com/camping/admin/support/context/ReservationWorld.java
@@ -2,4 +2,5 @@ package com.camping.admin.support.context;
 
 public class ReservationWorld extends World {
     public Long reservationId;
+    public String status;
 }

--- a/src/test/java/com/camping/admin/support/context/World.java
+++ b/src/test/java/com/camping/admin/support/context/World.java
@@ -1,0 +1,9 @@
+package com.camping.admin.support.context;
+
+import io.restassured.response.ExtractableResponse;
+
+public class World {
+    public String authToken;
+    public ExtractableResponse<?> response;
+    public String status;
+}

--- a/src/test/java/com/camping/admin/support/context/World.java
+++ b/src/test/java/com/camping/admin/support/context/World.java
@@ -5,5 +5,4 @@ import io.restassured.response.ExtractableResponse;
 public class World {
     public String authToken;
     public ExtractableResponse<?> response;
-    public String status;
 }

--- a/src/test/resources/features/reservation.feature
+++ b/src/test/resources/features/reservation.feature
@@ -1,5 +1,8 @@
 Feature: 예약 상태 변경
 
+  Background:
+    Given 관리자가 로그인을 하였다.
+
   Scenario: 관리자가 예약 상태를 변경하면, 예약의 상태가 해당 상태로 변경된다.
     Given WATING 상태인 예약이 존재한다.
     When 관리자가 WATING 상태인 예약 상태를 PENDING 상태로 변경한다.

--- a/src/test/resources/features/reservation.feature
+++ b/src/test/resources/features/reservation.feature
@@ -4,11 +4,15 @@ Feature: 예약 상태 변경
     Given 관리자가 로그인을 하였다.
 
   Scenario: 관리자가 예약 상태를 변경하면, 예약의 상태가 해당 상태로 변경된다.
-    Given WATING 상태인 예약이 존재한다.
-    When 관리자가 WATING 상태인 예약 상태를 PENDING 상태로 변경한다.
+    Given WAITING 상태인 예약이 존재한다.
+    When 관리자가 WAITING 상태인 예약 상태를 PENDING 상태로 변경한다.
     Then 예약 상태가 PENDING 으로 변경된다.
 
   Scenario: 관리자가 존재하지 않는 예약의 상태를 변경하면, 예외가 발생한다.
     Given 존재하지 않는 예약 ID 9999 가 있다.
     When 관리자가 예약 ID 9999 의 상태를 PENDING 상태로 변경한다.
     Then 에러 응답이 발생한다.
+
+  Scenario: 관리자가 공백 상태로 예약 상태를 변경하면, 기존 상태가 유지된다.
+    When 특정 예약에 대해 공백 상태로 예약 상태를 변경한다.
+    Then 예약 상태가 기존 상태로 유지된다.

--- a/src/test/resources/features/reservation.feature
+++ b/src/test/resources/features/reservation.feature
@@ -3,3 +3,8 @@ Feature: 예약 상태 변경
     Given WATING 상태인 예약이 존재한다.
     When 관리자가 WATING 상태인 예약 상태를 PENDING 상태로 변경한다.
     Then 예약 상태가 PENDING 으로 변경된다.
+
+  Scenario: 관리자가 존재하지 않는 예약의 상태를 변경하면, 예외가 발생한다.
+    Given 존재하지 않는 예약 ID 9999 가 있다.
+    When 관리자가 예약 ID 9999 의 상태를 PENDING 상태로 변경한다.
+    Then 에러 응답이 발생한다.

--- a/src/test/resources/features/reservation.feature
+++ b/src/test/resources/features/reservation.feature
@@ -1,4 +1,5 @@
 Feature: 예약 상태 변경
+
   Scenario: 관리자가 예약 상태를 변경하면, 예약의 상태가 해당 상태로 변경된다.
     Given WATING 상태인 예약이 존재한다.
     When 관리자가 WATING 상태인 예약 상태를 PENDING 상태로 변경한다.


### PR DESCRIPTION
안녕하세요 성현님!

2단계 미션 완료하여 리뷰 요청드립니다!!

궁금한 점 함께 남깁니다!

### 1. 컨텍스트 공유용 클래스 관리
저는 한번 pico container 를 사용해서 컨텍스트를 관리해보는 경험을 해보고자 적용해보았는데요! (잘 사용한건진 모르겠습니다 😅) 하다보니까 그 해당 컨텍스트 클래스를 작성하는데 고민이 되더라구요. 이 작성한 컨테이너를 퍼블릭하게 열어두어야 테스트 작성에 용이하겠지만, 이거 public 필드를 모두 public하게 여는것 자체를 본능적으로 거부한달까요..

결국 실용성에 맞추어 작성하였지만, 미션상황과 같은 간단한 어플리케이션을 테스트할 때여서 제가 이렇게 느끼는 건지, 복잡한 테스트 환경에서 인수테스트를 적용할 때에 이런식으로 테스트시 컨텍스트 전파용 객체더라도 public하게 열어놓으면 오히려 코드 관리에 있어서 단점도 있을 것 같더라구요! (흔히 말하는 예기치 못한 곳에서 변경되고 찾지 못하는.. 그런식으로 일관적인 동작을 막게되는 그런 부작용이 걱정되었습니다!)
그래서 성현님은 어떻게 생각하시는지 혹은 컨텍스트를 안전하게 공유하는 방식이 더 있을지 궁금합니다! 

### 2. features 파일 관리
step2를 진행하면서 각 스텝에 대한 재사용성을 고민하다보니, 재사용하기 좋게 features 파일의 단계를 잘게잘게 나누는 시도를 중간에 해보게 되었는데요 (실제로 적용하지는 않았습니다) 가령 이런 식입니다

```feature
// AS-IS
Scenario: 관리자가 예약 상태를 변경하면, 예약의 상태가 해당 상태로 변경된다.
    Given WAITING 상태인 예약이 존재한다.
    When 관리자가 WAITING 상태인 예약 상태를 PENDING 상태로 변경한다.
    Then 예약 상태가 PENDING 으로 변경된다.

// TO-BE
Scenario: 관리자가 예약 상태를 변경하면, 예약의 상태가 해당 상태로 변경된다.
    Given <before> 상태인 예약 ID <id> 가 존재한다
    When 관리자가 예약 ID <id> 의 상태를 <to> 로 변경한다
    Then HTTP 응답코드는 200 이다
    And 예약 상태는 <to> 이다
```

물론 현재 변경으로는 크지 않지만 실제로 각 Step에서 검증할 값이 많아지다보면 (And절이 늘어나면) 점차 API 스펙에만 집중되고 실제 검증하고자 하는 시나리오 그 자체에 대한 포커스가 떨어져서. 팀 내 공유 가능한 문서로서의 가치가 떨어진다고 생각이 들더라구요!
그래서 실제 적용할 때는 너무 잘게 Step을 나누면 안좋은 점도 있을 것 같은데 하는 생각이 들어서 이부분에 대해 성현님의 생각이 궁금했습니다!!


늦은 밤이다보니 제가 쓴 말이지만, 횡설수설한 감이 없지 않아 있네요 😅 혹시 이해안되시는 점 있으시면 코멘트 남겨주시면 상세히 질문드릴 수 있도록 하겠습니다!

리뷰 잘 부탁드립니다 💪💪💪